### PR TITLE
Clean up 'if true return true' snippet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl Bliss {
         // TODO Use good result
         let langs = self.supported_langs().unwrap();
 
-        if langs.contains(&lang.to_string()) { true } else { false }
+        langs.contains(&lang.to_string())
     } 
 
     /// Get the respective `.gitignore` for a given language


### PR DESCRIPTION
Hi - really cool project!
Just noticed the following and thought I'd clean it up 😄 
```rust
if langs.contains(&lang.to_string()) { true } else { false }
```